### PR TITLE
Bugfix: Allow json editor to render json column that is casted to array or object

### DIFF
--- a/resources/views/json-editor.blade.php
+++ b/resources/views/json-editor.blade.php
@@ -1,3 +1,9 @@
+@php
+    $statePath = $getStatePath();
+    if (if (is_array($statePath) || is_object($statePath) ) {
+        $statePath = json_encode($statePath);
+    }
+@endphp
 <x-forms::field-wrapper
     :id="$getId()"
     :label="$getLabel()"
@@ -8,7 +14,7 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }"
+    <div x-data="{ state: $wire.entangle('{{ $statePath }}') }"
          x-init="$nextTick(() => {
         const options = {
             modes: {{ $getModes() }},


### PR DESCRIPTION
Most people cast their json column as array or object

Hence this PR fix the issue where an array/object casted json column don't render.