### PR TITLE
Support json formatted data

### DIFF
--- a/resources/views/json-editor.blade.php
+++ b/resources/views/json-editor.blade.php
@@ -8,7 +8,13 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }"
+    <div class="w-full" x-data="{
+            state: $wire.entangle('{{ $getStatePath() }}'),
+            isJson: {{ json_encode($getJsonFormatted()) }},
+            get formattedState() {
+                return this.isJson ? this.state : JSON.parse(this.state)
+            }
+        }"
          x-init="$nextTick(() => {
         const options = {
             modes: {{ $getModes() }},
@@ -35,10 +41,10 @@
         };
         if(typeof json_editor !== 'undefined'){
             json_editor = new JSONEditor($refs.editor, options);
-            json_editor.set(JSON.parse(state));
+            json_editor.set(formattedState);
         }else{
             let json_editor = new JSONEditor($refs.editor, options);
-            json_editor.set(JSON.parse(state));
+            json_editor.set(formattedState);
         }
      })"
          x-cloak

--- a/src/Forms/JSONEditor.php
+++ b/src/Forms/JSONEditor.php
@@ -10,6 +10,7 @@ class JSONEditor extends Field
     public string $view = 'filament-jsoneditor::json-editor';
     protected int|Closure|null $height = 300;
     protected array|Closure|null $modes = ['code', 'form', 'text', 'tree', 'view', 'preview'];
+    protected bool $jsonFormatted = false;
 
     public function modes(array|Closure|null $modes): static
     {
@@ -25,6 +26,16 @@ class JSONEditor extends Field
         return $this;
     }
 
+    /**
+     * Is the model field casted to 'json'?
+     */
+    public function isJson(bool $state = true): static
+    {
+        $this->jsonFormatted = $state;
+
+        return $this;
+    }
+
     public function getHeight(): ?int
     {
         return $this->evaluate($this->height);
@@ -33,5 +44,11 @@ class JSONEditor extends Field
     public function getModes(): ?string
     {
         return json_encode($this->evaluate($this->modes));
+    }
+
+
+    public function getJsonFormatted(): bool
+    {
+        return $this->jsonFormatted;
     }
 }


### PR DESCRIPTION
This PR allows the field to accept pure JSON data.
This is the case if you have a model that casts the field to json.

In FooModel
```
    protected $casts = [
        'foo_field' => 'json',
    ];
```

Adds an `isJson(bool $state = true)` method to the field. 
Example:
```
\InvadersXX\FilamentJsoneditor\Forms\JSONEditor::make('foo_field')
        ->isJson()
        ->modes(['tree', 'view'])
```

This is a non-breaking change as the `bool $jsonFormatted` property is set to false by default.


TODO
It seems like the editor doesn't like other modes than `['tree', 'view']` if it receives json formatted data.
Don't know if this is the case for other data formats as well.
In my opinion I am fine with this limitation, a note added to the docs would be sufficient to cover the topic.