### PR TITLE
Css image path, isJson() obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ php artisan vendor:publish --tag=filament-jsoneditor-img
 
 This command will publish the jsoneditor button's img
 
+## Required format
+The Eloquent Model data must be cast to array or json
+
+Example:
+
+```php
+class MyModel extends Model
+{
+    protected $casts = [
+        'my_field' => 'array',
+        'another_field' => 'encrypted:json',
+    ];
+}
+```
+
 ## Usage
 
 ```php

--- a/resources/views/json-editor.blade.php
+++ b/resources/views/json-editor.blade.php
@@ -10,43 +10,39 @@
 >
     <div class="w-full" x-data="{
             state: $wire.entangle('{{ $getStatePath() }}'),
-            isJson: {{ json_encode($getJsonFormatted()) }},
-            get formattedState() {
-                return this.isJson ? this.state : JSON.parse(this.state)
-            }
         }"
          x-init="$nextTick(() => {
-        const options = {
-            modes: {{ $getModes() }},
-            history: true,
-            onChange: function(){
-            },
-            onChangeJSON: function(json){
-                state=JSON.stringify(json);
-            },
-            onChangeText: function(jsonString){
-                state=jsonString;
-            },
-            onValidationError: function (errors) {
-                errors.forEach((error) => {
-                  switch (error.type) {
-                    case 'validation': // schema validation error
-                      break;
-                    case 'error':  // json parse error
-                        console.log(error.message);
-                      break;
-                  }
-                })
+            const options = {
+                modes: {{ $getModes() }},
+                history: true,
+                onChange: function(){
+                },
+                onChangeJSON: function(json){
+                    state=JSON.stringify(json);
+                },
+                onChangeText: function(jsonString){
+                    state=jsonString;
+                },
+                onValidationError: function (errors) {
+                    errors.forEach((error) => {
+                      switch (error.type) {
+                        case 'validation': // schema validation error
+                          break;
+                        case 'error':  // json parse error
+                            console.log(error.message);
+                          break;
+                      }
+                    })
+                }
+            };
+            if(typeof json_editor !== 'undefined'){
+                json_editor = new JSONEditor($refs.editor, options);
+                json_editor.set(state);
+            } else {
+                let json_editor = new JSONEditor($refs.editor, options);
+                json_editor.set(state);
             }
-        };
-        if(typeof json_editor !== 'undefined'){
-            json_editor = new JSONEditor($refs.editor, options);
-            json_editor.set(formattedState);
-        }else{
-            let json_editor = new JSONEditor($refs.editor, options);
-            json_editor.set(formattedState);
-        }
-     })"
+         })"
          x-cloak
          wire:ignore>
             <div x-ref="editor" class="w-full ace_editor"

--- a/src/FilamentJsoneditorServiceProvider.php
+++ b/src/FilamentJsoneditorServiceProvider.php
@@ -29,7 +29,7 @@ class FilamentJsoneditorServiceProvider extends PackageServiceProvider
     {
         FilamentAsset::register([
             Css::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css'),
-            Js::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js')
+            Js::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js'),
         ], 'awcodes/headings');
     }
 }

--- a/src/FilamentJsoneditorServiceProvider.php
+++ b/src/FilamentJsoneditorServiceProvider.php
@@ -21,7 +21,7 @@ class FilamentJsoneditorServiceProvider extends PackageServiceProvider
             ->hasViews();
 
         $this->publishes([
-            __DIR__ . '/../dist/jsoneditor/img/jsoneditor-icons.svg' => public_path('filament/assets/img/jsoneditor-icons.svg'),
+            __DIR__ . '/../dist/jsoneditor/img/jsoneditor-icons.svg' => public_path('css/awcodes/headings/img/jsoneditor-icons.svg'),
         ], 'filament-jsoneditor-img');
     }
 

--- a/src/Forms/JSONEditor.php
+++ b/src/Forms/JSONEditor.php
@@ -27,6 +27,14 @@ class JSONEditor extends Field
         return $this;
     }
 
+    /**
+     * @deprecated obsolete, kept for backward compatibility
+     */
+    public function isJson(bool $state = true): static
+    {
+        return $this;
+    }
+
     public function getHeight(): ?int
     {
         return $this->evaluate($this->height);

--- a/src/Forms/JSONEditor.php
+++ b/src/Forms/JSONEditor.php
@@ -8,30 +8,21 @@ use Filament\Forms\Components\Field;
 class JSONEditor extends Field
 {
     public string $view = 'filament-jsoneditor::json-editor';
-    protected int|Closure|null $height = 300;
-    protected array|Closure|null $modes = ['code', 'form', 'text', 'tree', 'view', 'preview'];
-    protected bool $jsonFormatted = false;
 
-    public function modes(array|Closure|null $modes): static
+    protected int | Closure | null $height = 300;
+
+    protected array | Closure | null $modes = ['code', 'form', 'text', 'tree', 'view', 'preview'];
+
+    public function modes(array | Closure | null $modes): static
     {
         $this->modes = $modes;
 
         return $this;
     }
 
-    public function height(int|Closure|null $height): static
+    public function height(int | Closure | null $height): static
     {
         $this->height = $height;
-
-        return $this;
-    }
-
-    /**
-     * Is the model field casted to 'json'?
-     */
-    public function isJson(bool $state = true): static
-    {
-        $this->jsonFormatted = $state;
 
         return $this;
     }
@@ -48,10 +39,5 @@ class JSONEditor extends Field
         }
 
         return json_encode($this->evaluate($this->modes));
-    }
-
-    public function getJsonFormatted(): bool
-    {
-        return $this->jsonFormatted;
     }
 }


### PR DESCRIPTION
### Fixes: 
published css path for the image


### Non breaking change:

There is no need to check if the state is json because Livewire will encode any field value to json when using "entangle".
On the other hand it is required to cast the field data to array or json for the editor to accept the state as valid json.
I have update the readme and removed redundant code. 

The isJson() method has been marked as deprecated for backward compatibility