### PR TITLE
Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.0",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.74|^9.0|^10.0"
+        "illuminate/contracts": "^8.74|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^6.0",


### PR DESCRIPTION
This PR bumps the dependency of `illuminate\contracts` to allow for version 11, thereby enabling Laravel 11 apps to use the package.