### PR TITLE
Lazy load assets

### DIFF
--- a/resources/views/json-editor.blade.php
+++ b/resources/views/json-editor.blade.php
@@ -1,52 +1,64 @@
 <x-filament-forms::field-wrapper
-    :id="$getId()"
-    :label="$getLabel()"
-    :label-sr-only="$isLabelHidden()"
-    :helper-text="$getHelperText()"
-    :hint="$getHint()"
-    :hint-icon="$getHintIcon()"
-    :required="$isRequired()"
-    :state-path="$getStatePath()"
+        :id="$getId()"
+        :label="$getLabel()"
+        :label-sr-only="$isLabelHidden()"
+        :helper-text="$getHelperText()"
+        :hint="$getHint()"
+        :hint-icon="$getHintIcon()"
+        :required="$isRequired()"
+        :state-path="$getStatePath()"
 >
-    <div class="w-full" x-data="{
+    <div class="w-full"
+         x-load-css="['{{ asset('css/awcodes/headings/invaders-filament-jsoneditor.css') }}']"
+         data-js-before="app.js"
+         x-load-js="['{{ asset('js/awcodes/headings/invaders-filament-jsoneditor.js') }}']"
+         data-dispatch="jsoneditor-loaded"
+         x-on:jsoneditor-loaded-js.window="start"
+         x-data="{
             state: $wire.entangle('{{ $getStatePath() }}'),
-        }"
-         x-init="$nextTick(() => {
-            const options = {
-                modes: {{ $getModes() }},
-                history: true,
-                onChange: function(){
-                },
-                onChangeJSON: function(json){
-                    state=JSON.stringify(json);
-                },
-                onChangeText: function(jsonString){
-                    state=jsonString;
-                },
-                onValidationError: function (errors) {
-                    errors.forEach((error) => {
-                      switch (error.type) {
-                        case 'validation': // schema validation error
-                          break;
-                        case 'error':  // json parse error
-                            console.log(error.message);
-                          break;
-                      }
-                    })
-                }
-            };
-            if(typeof json_editor !== 'undefined'){
-                json_editor = new JSONEditor($refs.editor, options);
-                json_editor.set(state);
-            } else {
-                let json_editor = new JSONEditor($refs.editor, options);
-                json_editor.set(state);
+            editor: null,
+            destroy() {
+                this.editor = null;
+            },
+            start() {
+                $nextTick(() => {
+                    if(this.editor !== null) {
+                        return;
+                    }
+                    const options = {
+                        modes: {{ $getModes() }},
+                        history: true,
+                        onChange: () => {
+                            // onChange callback code if needed
+                        },
+                        onChangeJSON: (json) => {
+                            this.state = JSON.stringify(json);
+                        },
+                        onChangeText: (jsonString) => {
+                            this.state = jsonString;
+                        },
+                        onValidationError: (errors) => {
+                            errors.forEach((error) => {
+                                switch (error.type) {
+                                    case 'validation': // schema validation error
+                                        // Handle schema validation error
+                                        break;
+                                    case 'error':  // json parse error
+                                        console.log(error.message);
+                                        break;
+                                }
+                            });
+                        }
+                    };
+                    if(typeof JSONEditor !== 'undefined') {
+                        this.editor = new JSONEditor($refs.editor, options);
+                        Alpine.raw(this.editor).set(this.state);
+                    }
+                })
             }
-         })"
+        }"
          x-cloak
          wire:ignore>
-            <div x-ref="editor" class="w-full ace_editor"
-                 style="min-height: 30vh;height:{{ $getHeight() }}px"></div>
+        <div x-ref="editor" class="w-full ace_editor" style="min-height: 30vh;height:{{ $getHeight() }}px"></div>
     </div>
 </x-filament-forms::field-wrapper>
-

--- a/resources/views/json-editor.blade.php
+++ b/resources/views/json-editor.blade.php
@@ -9,9 +9,9 @@
         :state-path="$getStatePath()"
 >
     <div class="w-full"
-         x-load-css="['{{ asset('css/awcodes/headings/invaders-filament-jsoneditor.css') }}']"
+         x-load-css="[@js(\Filament\Support\Facades\FilamentAsset::getStyleHref('invaders-filament-jsoneditor', package: 'invaders/jsoneditor'))]"
          data-js-before="app.js"
-         x-load-js="['{{ asset('js/awcodes/headings/invaders-filament-jsoneditor.js') }}']"
+         x-load-js="[@js(\Filament\Support\Facades\FilamentAsset::getScriptSrc('invaders-filament-jsoneditor', package: 'invaders/jsoneditor'))]"
          data-dispatch="jsoneditor-loaded"
          x-on:jsoneditor-loaded-js.window="start"
          x-data="{
@@ -19,6 +19,7 @@
             editor: null,
             destroy() {
                 this.editor = null;
+                console.info('destroy');
             },
             start() {
                 $nextTick(() => {

--- a/src/FilamentJsoneditorServiceProvider.php
+++ b/src/FilamentJsoneditorServiceProvider.php
@@ -22,14 +22,18 @@ class FilamentJsoneditorServiceProvider extends PackageServiceProvider
 
         $this->publishes([
             __DIR__ . '/../dist/jsoneditor/img/jsoneditor-icons.svg' => public_path('css/awcodes/headings/img/jsoneditor-icons.svg'),
-        ], 'filament-jsoneditor-img');
+            __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css' => public_path('css/awcodes/headings/jsoneditor.min.css'),
+            __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js' => public_path('js/awcodes/headings/jsoneditor.min.js'),
+        ], 'filament-jsoneditor');
     }
 
-    public function packageBooted(): void
+    public function packageRegistered(): void
     {
-        FilamentAsset::register([
-            Css::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css'),
-            Js::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js'),
-        ], 'awcodes/headings');
+        if ($this->app->runningInConsole()) {
+            FilamentAsset::register([
+                Css::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css'),
+                Js::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js'),
+            ], 'awcodes/headings');
+        }
     }
 }

--- a/src/FilamentJsoneditorServiceProvider.php
+++ b/src/FilamentJsoneditorServiceProvider.php
@@ -16,24 +16,18 @@ class FilamentJsoneditorServiceProvider extends PackageServiceProvider
     {
         $package
             ->name(static::$name)
-            ->hasConfigFile()
-            ->hasAssets()
             ->hasViews();
 
         $this->publishes([
-            __DIR__ . '/../dist/jsoneditor/img/jsoneditor-icons.svg' => public_path('css/awcodes/headings/img/jsoneditor-icons.svg'),
-            __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css' => public_path('css/awcodes/headings/jsoneditor.min.css'),
-            __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js' => public_path('js/awcodes/headings/jsoneditor.min.js'),
-        ], 'filament-jsoneditor');
+            __DIR__ . '/../dist/jsoneditor/img/jsoneditor-icons.svg' => public_path('css/invaders/jsoneditor/img/jsoneditor-icons.svg'),
+        ], 'filament-jsoneditor-img');
     }
 
-    public function packageRegistered(): void
+    public function packageBooted(): void
     {
-        if ($this->app->runningInConsole()) {
-            FilamentAsset::register([
-                Css::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css'),
-                Js::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js'),
-            ], 'awcodes/headings');
-        }
+        FilamentAsset::register([
+            Css::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.css')->loadedOnRequest(),
+            Js::make('invaders-filament-jsoneditor', __DIR__ . '/../dist/jsoneditor/jsoneditor.min.js')->loadedOnRequest(),
+        ], 'invaders/jsoneditor');
     }
 }


### PR DESCRIPTION
This PR can only be accepted when Filament uses the latest version of Alpine lazy load assets.
https://github.com/filamentphp/filament/pull/14239

## Description
Filament includes an Alpine plugin to lazy load assets, this PR adds support for that.
Meaning that the js and css needed for this filament field, will only be loaded on pages where it is actually being used.
https://www.npmjs.com/package/alpine-lazy-load-assets


I have tested the changes with Filament spa mode enabled/disabled

## Changes to the service provider
- it uses this package name, not other plugin author, to avoid potential naming conflicts
- it tells Filament to load the assets when requested, not on every page.

## Changes to the blade file
- it loads the assets only on pages where the field is used
- it pushes css to the head
- it makes sure the script is loaded before app.js
- it dispatches a window event when the script is loaded
- it delays initiation of the field until the script is loaded
- it properly destroys the input when on Alpine.destroy()
- it prevents re-initiating the field if the window event is dispatched multiple times
- it checks that JSONEditor is available



